### PR TITLE
面接日程の表示、登録、編集、削除機能の実装

### DIFF
--- a/app/assets/javascripts/interviews.coffee
+++ b/app/assets/javascripts/interviews.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -44,3 +44,6 @@
    color: #f88;
    text-decoration: underline;
  }
+ .alert {
+   color: red;
+ }

--- a/app/assets/stylesheets/interviews.scss
+++ b/app/assets/stylesheets/interviews.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Interviews controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,0 +1,2 @@
+class InterviewsController < ApplicationController
+end

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -12,6 +12,8 @@ class InterviewsController < ApplicationController
 
   def create
     @interview = Interview.new(interview_params)
+    @interview.user_id = params[:user_id]
+
     if @interview.save
       redirect_to user_interviews_url, notice: "新規面接日程を作成しました。"
     else
@@ -45,6 +47,6 @@ class InterviewsController < ApplicationController
   end
 
   def interview_params
-    params.require(:interview).permit(:interview_date).merge(user_id: params[:user_id])
+    params.require(:interview).permit(:interview_date)
   end
 end

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,2 +1,25 @@
 class InterviewsController < ApplicationController
+  def index
+    @interviews = current_user.interviews.order("interview_date DESC")
+  end
+
+  def new
+    @user = current_user
+    @interview = Interview.new
+  end
+
+  def create
+    @user = current_user
+    @interview = Interview.new(interview_params)
+    if @interview.save
+      redirect_to user_interviews_url
+    else
+      render 'new'
+    end
+  end
+
+  private
+  def interview_params
+    params.require(:interview).permit(:interview_date).merge(user_id: params[:user_id])
+  end
 end

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,47 +1,49 @@
 class InterviewsController < ApplicationController
+  before_action :set_user, except: :destroy
+  before_action :set_interview, only: [:edit, :update, :destroy]
+
   def index
-    @user = current_user
     @interviews = current_user.interviews.order("interview_date DESC")
   end
 
   def new
-    @user = current_user
     @interview = Interview.new
   end
 
   def create
-    @user = current_user
     @interview = Interview.new(interview_params)
     if @interview.save
-      redirect_to user_interviews_url
+      redirect_to user_interviews_url, notice: "新規面接日程を作成しました。"
     else
-      render 'new'
+      render action: :new
     end
   end
 
   def edit
-    @user = current_user
-    @interview = Interview.find(params[:id])
   end
 
   def update
-    @user = current_user
-    @interview = Interview.find(params[:id])
     if  @interview.update(interview_params)
-      redirect_to user_interviews_url
+      redirect_to user_interviews_url, notice: "面接日時を更新しました。"
     else
-      render 'edit'
+      render action: :edit
     end
   end
 
   def destroy
-    @user = current_user
-    @interview = Interview.find(params[:id])
     @interview.destroy
-    redirect_to user_interviews_url
+    redirect_to user_interviews_url, notice: "面接日時を削除しました。"
   end
 
   private
+  def set_user
+    @user = current_user
+  end
+
+  def set_interview
+    @interview = Interview.find(params[:id])
+  end
+
   def interview_params
     params.require(:interview).permit(:interview_date).merge(user_id: params[:user_id])
   end

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,5 +1,6 @@
 class InterviewsController < ApplicationController
   def index
+    @user = current_user
     @interviews = current_user.interviews.order("interview_date DESC")
   end
 
@@ -16,6 +17,28 @@ class InterviewsController < ApplicationController
     else
       render 'new'
     end
+  end
+
+  def edit
+    @user = current_user
+    @interview = Interview.find(params[:id])
+  end
+
+  def update
+    @user = current_user
+    @interview = Interview.find(params[:id])
+    if  @interview.update(interview_params)
+      redirect_to user_interviews_url
+    else
+      render 'edit'
+    end
+  end
+
+  def destroy
+    @user = current_user
+    @interview = Interview.find(params[:id])
+    @interview.destroy
+    redirect_to user_interviews_url
   end
 
   private

--- a/app/helpers/interviews_helper.rb
+++ b/app/helpers/interviews_helper.rb
@@ -1,0 +1,2 @@
+module InterviewsHelper
+end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,0 +1,2 @@
+class Interview < ApplicationRecord
+end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,2 +1,3 @@
 class Interview < ApplicationRecord
+  belongs_to :user
 end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,3 +1,12 @@
 class Interview < ApplicationRecord
   belongs_to :user
+  enum interview_status: { reserve: 0, approval: 1, disapproval: 2 }
+
+  validate :datetime_cannot_be_in_the_past
+
+  def datetime_cannot_be_in_the_past
+    if interview_date.past?
+      errors.add(:interview_datetime, "日時は現在以降の時間を設定してください。")
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,6 @@ class User < ApplicationRecord
   validates :email, presence: true
 
   enum sex: { man: 1, woman: 2 }
+
+  has_many :interviews
 end

--- a/app/views/interviews/_error_message.html.erb
+++ b/app/views/interviews/_error_message.html.erb
@@ -1,0 +1,7 @@
+<% if @interview.errors.any? %>
+  <% @interview.errors.full_messages.each do |msg| %>
+    <div class="alert">
+      <li><%= msg %></li>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/interviews/edit.html.erb
+++ b/app/views/interviews/edit.html.erb
@@ -1,0 +1,9 @@
+<h1>インタビューを編集</h1>
+
+<%= form_for [@user, @interview] do |f| %>
+
+  <%= f.label :interview_date, "Interview Date" %><br>
+  <%= f.datetime_select :interview_date %>
+
+  <%= f.submit "インタビューを編集" %>
+<% end %>

--- a/app/views/interviews/edit.html.erb
+++ b/app/views/interviews/edit.html.erb
@@ -1,9 +1,11 @@
-<h1>インタビューを編集</h1>
+<% provide(:title, "面接日程の編集") %>
+<%= render 'error_message' %>
+<h1>面接日程の編集</h1>
 
 <%= form_for [@user, @interview] do |f| %>
 
-  <%= f.label :interview_date, "Interview Date" %><br>
+  <%= f.label :interview_date, "面接日程" %><br>
   <%= f.datetime_select :interview_date %>
 
-  <%= f.submit "インタビューを編集" %>
+  <%= f.submit "面接日程の編集" %>
 <% end %>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -4,6 +4,6 @@
 <% @interviews.each do |interview| %>
   <%= interview.interview_date.strftime('%Y年%m月%d日%H時%M分') %>
   <%= link_to "編集", edit_user_interview_path(@user, interview) %>
-  <%= link_to "削除", user_interview_path(@user,interview), method: :delete, data: { confirm: '本当によろしいですか?' } %><br>
+  <%= link_to "削除", user_interview_path(@user, interview), method: :delete, data: { confirm: '本当によろしいですか?' } %><br>
 <% end %>
 <%= link_to "新規面接作成", new_user_interview_path %>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -1,10 +1,9 @@
-<h1>スケジュール一覧</h1>
+<% provide(:title, "面接日程一覧") %>
+<h1><%= @user.name %>さんの面接一覧</h1>
 
 <% @interviews.each do |interview| %>
-  <%= interview.interview_date %><br>
+  <%= interview.interview_date.strftime('%Y年%m月%d日%H時%M分') %>
   <%= link_to "編集", edit_user_interview_path(@user, interview) %>
-  <%= link_to "削除", user_interview_path(@user,interview), method: :delete %><br>
+  <%= link_to "削除", user_interview_path(@user,interview), method: :delete, data: { confirm: '本当によろしいですか?' } %><br>
 <% end %>
-<br>
-<%= link_to "新規スケジュール作成", new_user_interview_path %><br>
-<%= link_to "トップページに戻る", users_path %>
+<%= link_to "新規面接作成", new_user_interview_path %>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -2,7 +2,9 @@
 
 <% @interviews.each do |interview| %>
   <%= interview.interview_date %><br>
+  <%= link_to "編集", edit_user_interview_path(@user, interview) %>
+  <%= link_to "削除", user_interview_path(@user,interview), method: :delete %><br>
 <% end %>
 <br>
-<%= link_to "新規スケジュール作成", new_user_interview_path %><br><br>
+<%= link_to "新規スケジュール作成", new_user_interview_path %><br>
 <%= link_to "トップページに戻る", users_path %>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -1,0 +1,8 @@
+<h1>スケジュール一覧</h1>
+
+<% @interviews.each do |interview| %>
+  <%= interview.interview_date %><br>
+<% end %>
+<br>
+<%= link_to "新規スケジュール作成", new_user_interview_path %><br><br>
+<%= link_to "トップページに戻る", users_path %>

--- a/app/views/interviews/new.html.erb
+++ b/app/views/interviews/new.html.erb
@@ -1,0 +1,9 @@
+<h1>新規スケジュール作成</h1>
+
+<%= form_for [@user, @interview] do |f| %>
+
+  <%= f.label :interview_date, "Interview Date" %><br>
+  <%= f.datetime_select :interview_date %>
+
+  <%= f.submit "新規スケジュール作成" %>
+<% end %>

--- a/app/views/interviews/new.html.erb
+++ b/app/views/interviews/new.html.erb
@@ -1,9 +1,11 @@
-<h1>新規スケジュール作成</h1>
+<% provide(:title, "新規面接作成") %>
+<%= render 'error_message' %>
+<h1>新規面接作成</h1>
 
 <%= form_for [@user, @interview] do |f| %>
 
-  <%= f.label :interview_date, "Interview Date" %><br>
+  <%= f.label :interview_date, "日時追加" %><br>
   <%= f.datetime_select :interview_date %>
 
-  <%= f.submit "新規スケジュール作成" %>
+  <%= f.submit "新規面接作成" %>
 <% end %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -2,6 +2,7 @@
   <nav class="menubar">
     <%= link_to "e-Navigator", root_path %>
     <%= link_to "プロフィール編集", edit_user_path(current_user) %>
+    <%= link_to "インタビューリスト", user_interviews_path(current_user) %>
     <%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: { confirm: '本当によろしいですか?' } %>
   </nav>
 <% end %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -2,7 +2,7 @@
   <nav class="menubar">
     <%= link_to "e-Navigator", root_path %>
     <%= link_to "プロフィール編集", edit_user_path(current_user) %>
-    <%= link_to "インタビューリスト", user_interviews_path(current_user) %>
+    <%= link_to "自分の面接日程一覧", user_interviews_path(current_user) %>
     <%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: { confirm: '本当によろしいですか?' } %>
   </nav>
 <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,5 +27,7 @@ module ENavigator
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    config.time_zone = 'Asia/Tokyo'
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   root 'users#index'
   devise_for :users
-  resources :users
+  resources :users do
+    resources :interviews
+  end
 end

--- a/db/migrate/20190313040308_create_interviews.rb
+++ b/db/migrate/20190313040308_create_interviews.rb
@@ -1,0 +1,10 @@
+class CreateInterviews < ActiveRecord::Migration[5.1]
+  def change
+    create_table :interviews do |t|
+      t.datetime :interview_date
+      t.integer :interview_status
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190313040308_create_interviews.rb
+++ b/db/migrate/20190313040308_create_interviews.rb
@@ -1,8 +1,8 @@
 class CreateInterviews < ActiveRecord::Migration[5.1]
   def change
     create_table :interviews do |t|
-      t.datetime :interview_date
-      t.integer :interview_status
+      t.datetime :interview_date, null: false
+      t.integer :interview_status, null: false, default: 0
 
       t.timestamps
     end

--- a/db/migrate/20190313045653_add_userid_to_interviews.rb
+++ b/db/migrate/20190313045653_add_userid_to_interviews.rb
@@ -1,0 +1,5 @@
+class AddUseridToInterviews < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :interviews, :user
+  end
+end

--- a/db/migrate/20190313050552_change_column_to_interviews.rb
+++ b/db/migrate/20190313050552_change_column_to_interviews.rb
@@ -1,0 +1,5 @@
+class ChangeColumnToInterviews < ActiveRecord::Migration[5.1]
+  def change
+    change_column :interviews, :user_id, :integer, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190226050230) do
+ActiveRecord::Schema.define(version: 20190313040308) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "interviews", force: :cascade do |t|
+    t.datetime "interview_date"
+    t.integer "interview_status"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,16 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190313040308) do
+ActiveRecord::Schema.define(version: 20190313050552) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "interviews", force: :cascade do |t|
-    t.datetime "interview_date"
-    t.integer "interview_status"
+    t.datetime "interview_date", null: false
+    t.integer "interview_status", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.index ["user_id"], name: "index_interviews_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION

やりたかったこと
---
面接日程の一覧表示、登録機能の実装
面接日程の編集、削除機能の実装

やったこと
----

  自分の面接一覧リンク作成
  面接の新規作成機能追加
  面接一覧から面接の編集機能追加
  面接一覧から面接の削除機能追加

動作確認方法
---
トップページからヘッダーの面接一覧へ移動。
面接を新規登録するをクリック。
登録された面接が表示されていることを確認。
面接を編集するボタンを押すと、編集できる。
削除ボタンを押したら面接情報が削除されている。

デプロイ先URL
---
https://e-navigator-takukik.herokuapp.com/

よろしくお願いします。