### PR TITLE
接官が面談日程を承認 or 拒否するための機能

### DIFF
--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,9 +1,12 @@
 class InterviewsController < ApplicationController
-  before_action :set_user, except: :destroy
-  before_action :set_interview, only: [:edit, :update, :destroy]
+  before_action :set_user, except: [:destroy, :setup]
+  before_action :set_interview, only: [:edit, :update, :destroy, :setup]
 
   def index
     @interviews = current_user.interviews.order("interview_date DESC")
+  end
+
+  def show
   end
 
   def new
@@ -35,6 +38,17 @@ class InterviewsController < ApplicationController
   def destroy
     @interview.destroy
     redirect_to user_interviews_url, notice: "面接日時を削除しました。"
+  end
+
+  def setup
+    others = Interview.where(user_id: params[:user_id]).where.not(id: params[:id])
+    @interview.user_id = params[:user_id]
+    if @interview.update(interview_status: 1)
+      others.update_all(interview_status: 2)
+      redirect_to user_interviews_url(params[:user_id]), notice: "面談日時が設定されました。"
+    else
+      render action: :edit
+    end
   end
 
   private

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -3,7 +3,7 @@ class InterviewsController < ApplicationController
   before_action :set_interview, only: [:edit, :update, :destroy, :setup]
 
   def index
-    @interviews = current_user.interviews.order("interview_date DESC")
+    @interviews = @user.interviews.order("interview_date DESC")
   end
 
   def show
@@ -42,7 +42,6 @@ class InterviewsController < ApplicationController
 
   def setup
     others = Interview.where(user_id: params[:user_id]).where.not(id: params[:id])
-    @interview.user_id = params[:user_id]
     if @interview.update(interview_status: 1)
       others.update_all(interview_status: 2)
       redirect_to user_interviews_url(params[:user_id]), notice: "面談日時が設定されました。"

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -39,7 +39,7 @@ class InterviewsController < ApplicationController
 
   private
   def set_user
-    @user = current_user
+    @user = User.find(params[:user_id])
   end
 
   def set_interview

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
   before_action :set_user, only: [:edit, :update]
   def index
-    @users = User.all
+    @users = User.where.not(id: current_user.id)
   end
 
   def edit

--- a/app/helpers/interviews_helper.rb
+++ b/app/helpers/interviews_helper.rb
@@ -1,2 +1,14 @@
 module InterviewsHelper
+
+  def get_current_interview(user)
+    Interview.find_by(user_id: user.id, interview_status: 1)
+  end
+
+  def check_current_interview(interview)
+    interview ? "#{date_format(interview)}に面談が設定されています" : "現在面談は設定されていません"
+  end
+
+  def date_format(interview)
+    return interview.interview_date.strftime("%Y年%m月%d日%H時%M分") if interview
+  end
 end

--- a/app/views/interviews/_other_index.html.erb
+++ b/app/views/interviews/_other_index.html.erb
@@ -1,0 +1,12 @@
+<h2>面談日程</h2>
+<div>
+  <%= check_current_interview(get_current_interview(@user)) %>
+</div>
+
+<div>
+  <p>面談日程を変更する場合は以下から選択してください。</p>
+<% @interviews.each do |interview| %>
+    <% date = date_format(interview) %>
+    <%= link_to "#{date}", setup_user_interview_path(@user, interview), method: :patch, data: { confirm: "面談を#{date}に設定しますか？" } unless interview.interview_status == "approval" %>
+<% end %>
+</div>

--- a/app/views/interviews/_self_index.html.erb
+++ b/app/views/interviews/_self_index.html.erb
@@ -1,0 +1,21 @@
+<table class="list">
+  <thead>
+    <tr>
+      <th>日付</th>
+      <th>承認状態</th>
+      <th colspan="2"></th>
+    </tr>
+  </thead>
+  <tbody>
+  <% @interviews.each do |interview| %>
+    <tr>
+      <td><%= interview.interview_date.strftime('%Y年%m月%d日%H時%M分') %></td>
+      <td><%= interview.interview_status %></td>
+      <td><%= link_to "編集", edit_user_interview_path(@user, interview) %></td>
+      <td><%= link_to "削除", user_interview_path(@user, interview), method: :delete, data: { confirm: '本当によろしいですか?' } %></td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>
+<br>
+<%= link_to "新規面接作成", new_user_interview_path %>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -1,9 +1,12 @@
 <% provide(:title, "面接日程一覧") %>
-<h1><%= @user.name %>さんの面接一覧</h1>
-
-<% @interviews.each do |interview| %>
-  <%= interview.interview_date.strftime('%Y年%m月%d日%H時%M分') %>
-  <%= link_to "編集", edit_user_interview_path(@user, interview) %>
-  <%= link_to "削除", user_interview_path(@user, interview), method: :delete, data: { confirm: '本当によろしいですか?' } %><br>
+<% if @user.name.present? %>
+  <h1><%= @user.name %>さんの面接一覧</h1>
+<% else %>
+  <h1><%= @user.email %>さんの面接一覧</h1>
 <% end %>
-<%= link_to "新規面接作成", new_user_interview_path %>
+
+<% if current_user == @user %>
+  <%= render 'interviews/self_index' %>
+<% else %>
+  <%= render 'interviews/other_index' %>
+<% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -10,6 +10,8 @@
         <th>生年月日</th>
         <th>性別</th>
         <th>学校名</th>
+        <th>面接日程</th>
+        <th scope="col"></th>
       </tr>
     </thead>
     <tbody>
@@ -20,6 +22,8 @@
           <td><%= user.birthday %></td>
           <td><%= user.sex %></td>
           <td><%= user.school %></td>
+          <td><%= date_format(get_current_interview(user)) %></td>
+          <td><%= link_to "面接一覧", user_interviews_path(user) %></td>
         </tr>
       <% end %>
     </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,10 @@ Rails.application.routes.draw do
   root 'users#index'
   devise_for :users
   resources :users do
-    resources :interviews
+    resources :interviews do
+      member do
+        patch :setup
+      end
+    end
   end
 end


### PR DESCRIPTION
やりたかったこと
---
・自分以外のユーザーの一覧をトップページに表示する。
・面接希望日一覧を表示する。
・ユーザーの面談日程を承認できるようにする。

やったこと
----

- 面談承認のためのactionを追加。
- 面接希望日一覧を表示する。
- 自分以外のユーザーの面談日程を承認できるようにする。


動作確認方法
---

・ログインして面談希望日を登録する。
・別ユーザーでログインし、先ほどの面談希望日の中から1件承認できることを確認する。
・該当日程が承認、その他の日程は却下になっていることを確認する。
・上記の面談日程が編集、削除できないことを確認する。

その他
---
デプロイ先
https://e-navigator-takukik.herokuapp.com
